### PR TITLE
fix: add csrf token to event context

### DIFF
--- a/src/runtime/server/plugin/csrf.ts
+++ b/src/runtime/server/plugin/csrf.ts
@@ -24,7 +24,7 @@ export default defineNitroPlugin((nitroApp) => {
   });
 
   nitroApp.hooks.hook('render:html', async (html, { event }) => {
-    if(event.context.csrfToken){
+    if(!event.context.csrfToken){
       return;
     }
     html.head.push(`<meta name="csrf-token" content="${event.context.csrfToken}">`)


### PR DESCRIPTION
1. Add nitro request hook.
2. Add CSRF token to event context, making it accessible in pages.

see issue #20 