### PR TITLE
Keep plugin type after building

### DIFF
--- a/src/runtime/plugin.ts
+++ b/src/runtime/plugin.ts
@@ -1,8 +1,10 @@
-import { $fetch } from 'ofetch'
-import type { FetchOptions } from 'ofetch'
+import { type FetchOptions, $fetch } from 'ofetch'
+import type { Plugin } from '#app'
 import { defineNuxtPlugin, useCsrf } from '#imports'
 
-export default defineNuxtPlugin(() => {
+type CsrfFetch = (request: string, options?: FetchOptions, fetch?: typeof $fetch) => Promise<any>
+
+const plugin: Plugin<{ csrfFetch: CsrfFetch }> = defineNuxtPlugin(() => {
   const { csrf } = useCsrf()
   return {
     provide: {
@@ -15,3 +17,5 @@ export default defineNuxtPlugin(() => {
     }
   }
 })
+
+export default plugin


### PR DESCRIPTION
May fix https://github.com/Morgbn/nuxt-csurf/issues/19

It seems that there is an issue in `nuxt-module-builder` that makes plugin types  are not preserved in build output.
This fix takes reference from the fix in `@nuxt/pinia` module https://github.com/vuejs/pinia/pull/2147