### PR TITLE
Add CSRF secret to the event context

### DIFF
--- a/src/runtime/server/plugin/csrf.ts
+++ b/src/runtime/server/plugin/csrf.ts
@@ -20,6 +20,7 @@ export default defineNitroPlugin((nitroApp) => {
         setCookie(event, cookieKey, secret, csrfConfig.cookie)
       }
       event.context.csrfToken = await csrf.create(secret, await useSecretKey(csrfConfig), csrfConfig.encryptAlgorithm)
+      event.context.csrfSecret = secret
     })
     nitroApp.hooks.hook('render:html', async (html, { event }) => {
       html.head.push(`<meta name="csrf-token" content="${event.context.csrfToken}">`)


### PR DESCRIPTION
Hi!

While 1.4.0 added the CSRF token to the event context, the secret should also be added.

I have a situation where I use urql and on the server side it doesn't see the secret cookie on the first request so it always fails.

With this I can get the secret key from the context and add it the to request when cookies are missing.