### PR TITLE
Showing the config bug

### DIFF
--- a/playground/pages/index.vue
+++ b/playground/pages/index.vue
@@ -44,7 +44,7 @@ const testPost = async (withCsrf, url = '/test') => {
   if (error.value) { msgColor.value = 'red' }
 }
 
-const testPut = async (withCsrf, url = '/test-put') => {
+const testPut = async (withCsrf, url = '/test') => {
   msg.value = null
   msgColor.value = 'green'
   const fetch = withCsrf ? useCsrfFetch : useFetch

--- a/playground/pages/index.vue
+++ b/playground/pages/index.vue
@@ -14,6 +14,9 @@
     <button @click="testPost(true, '/error')">
       POST /error (throw an error one time in two)
     </button>
+    <button @click="testPut()">
+      PUT /put-test (without csrf header)
+    </button>
     <br>
     <br>
     <pre
@@ -40,6 +43,16 @@ const testPost = async (withCsrf, url = '/test') => {
   msg.value = data.value || error.value
   if (error.value) { msgColor.value = 'red' }
 }
+
+const testPut = async (withCsrf, url = '/test-put') => {
+  msg.value = null
+  msgColor.value = 'green'
+  const fetch = withCsrf ? useCsrfFetch : useFetch
+  const { data, error } = await fetch('/api' + url, { method: 'PUT' })
+  msg.value = data.value || error.value
+  if (error.value) { msgColor.value = 'red' }
+}
+
 
 const { data: preFetchedData } = useCsrfFetch('/api/data', { params: { d: 'specific' } })
 // Need "addCsrfTokenToEventCtx" to be true in csurf config (in nuxt.config.js)

--- a/playground/server/api/test.put.ts
+++ b/playground/server/api/test.put.ts
@@ -1,0 +1,2 @@
+import { defineEventHandler } from 'h3'
+export default defineEventHandler(() => 'Test put success')


### PR DESCRIPTION
The issue:

In the playground, the nuxt config is setup for "POST" only, but the lib doesn't respect that. It's guarding PUT's as well. 

```
  csurf: {
    https: false,
    methodsToProtect: ['POST']
  }
```
![image](https://github.com/Morgbn/nuxt-csurf/assets/5285928/f03df92a-ceb1-49f6-8dfd-bad8907a457e)

This is to do with the default that are setup in the module.ts

However, I'm not familiar with this, so  I haven't fixed it here. 

Any thoughts? @Morgbn 