### PR TITLE
Add augumentation to `@nuxt/schema`

### DIFF
--- a/src/module.ts
+++ b/src/module.ts
@@ -55,7 +55,7 @@ export default defineNuxtModule<ModuleOptions>({
   }
 })
 
-declare module 'nuxt/schema' {
+declare module '@nuxt/schema' {
   interface RuntimeConfig {
     csurf: ModuleOptions
   }


### PR DESCRIPTION
Per the note here: https://nuxt.com/docs/guide/going-further/runtime-config#typing-runtime-config

```sh
nuxt/schema is provided as a convenience for end-users to access the version of the schema used by Nuxt in their project. Module authors should instead augment @nuxt/schema.
```