### PR TITLE
fix: support h3 v2

### DIFF
--- a/src/runtime/server/middleware/csrf.ts
+++ b/src/runtime/server/middleware/csrf.ts
@@ -1,8 +1,10 @@
 import * as csrf from 'uncsrf'
-import { defineEventHandler, getCookie, getHeader, createError } from 'h3'
 import { useSecretKey } from '../helpers'
 import { defuReplaceArray } from '../../utils'
-import { useRuntimeConfig, getRouteRules } from '#imports'
+// Import h3 utilities from `#imports` (Nitro auto-imports) rather than `h3`,
+// so they resolve to the same h3 instance Nitro uses to build the event.
+// This keeps the module compatible with both h3 v1 and v2.
+import { defineEventHandler, getCookie, getHeader, createError, useRuntimeConfig, getRouteRules } from '#imports'
 
 const baseConfig = useRuntimeConfig().csurf
 
@@ -11,7 +13,7 @@ export default defineEventHandler(async (event) => {
   if (csurf === false || csurf?.enabled === false) return // csrf protection disabled for this route
 
   const csrfConfig = defuReplaceArray(csurf, baseConfig)
-  const method = event.node.req.method ?? ''
+  const method = event.method ?? ''
   const methodsToProtect = csrfConfig.methodsToProtect ?? []
   if (!methodsToProtect.includes(method)) return
 

--- a/src/runtime/server/plugin/csrf.ts
+++ b/src/runtime/server/plugin/csrf.ts
@@ -1,8 +1,10 @@
 import * as csrf from 'uncsrf'
-import { getCookie, setCookie } from 'h3'
 import type { NitroApp } from 'nitropack'
 import { useSecretKey } from '../helpers'
-import { useRuntimeConfig, getRouteRules } from '#imports'
+// Import h3 utilities from `#imports` (Nitro auto-imports) rather than `h3`,
+// so they resolve to the same h3 instance Nitro uses to build the event.
+// This keeps the module compatible with both h3 v1 and v2.
+import { getCookie, setCookie, useRuntimeConfig, getRouteRules } from '#imports'
 
 type NitroAppPlugin = (nitro: NitroApp) => void
 


### PR DESCRIPTION
## Problem

On a Nuxt 4 / h3 v2 app, the module crashes with:

```
event.req.headers.get is not a function
  at parseCookies (h3@2.0.1-rc.22/.../h3.mjs)
  at getCookie (h3@2.0.1-rc.22/.../h3.mjs)
  at runtime/server/plugin/csrf.js
```

The root cause is a **dual h3-version mismatch**, not just a changed API. The server runtime did:

```ts
import { getCookie, setCookie } from 'h3'
```

In an h3 v2 app that bare `h3` specifier resolves to the app's **h3 v2**, but Nitro builds the request event with its **own** bundled h3. A `getCookie` from one h3 instance handed an event shaped by another blows up inside `parseCookies`.

## Fix

Resolve the h3 server utilities from **Nitro's auto-imports (`#imports`)** instead of `h3`. Nitro auto-imports every lowercase h3 export from *its own* h3 instance, so the helper and the event are guaranteed to share a version — on both h3 v1 and v2. This matches the existing pattern (the files already imported `useRuntimeConfig`/`getRouteRules` from `#imports`).

Also replaced the v1-only `event.node.req.method` with `event.method`, which works on both v1 and v2 (`event.node` is Node-runtime-only and deprecated in v2).

## Compatibility

- **h3 v1**: unchanged — same utility functions, just sourced from the matching h3 instance. `event.method` has been an `H3Event` getter since h3 v1.8.
- **h3 v2**: no longer crashes.

## Verification

- `dev:prepare`, `build`, `lint` all pass.
- Live smoke-test against the playground (h3 v1): SSR `<meta name="csrf-token">` injected + cookie set, valid cookie+token POST → `200`, missing token → `403`, bad token → `403`, no runtime errors.
